### PR TITLE
Added fatal error for "Returning error because of i/o error...

### DIFF
--- a/htseq2multx.pl
+++ b/htseq2multx.pl
@@ -8,9 +8,12 @@ use IO::Select;
 use English qw(-no_match_vars);
 use Readonly;
 
-our $VERSION     = '0.1';    #Version of this script
+our $VERSION     = '0.2';    #Version of this script
 our $BCSVERSION  = '0.18.6'; #Emulated barcode_splitter version
 our $FQMXVERSION = '1.4';    #Minimum required fastq-multx version
+
+# CHANGE LOG
+# 0.2 Added fatal error: Returning error because of i/o error during file close
 
 #Exit codes (mimmicking barcode_splitter)
 Readonly::Scalar my $SUCCESS         => 0;
@@ -947,10 +950,11 @@ sub processSTDERR
     my $filter_pat  = join('|',@$filter_pats);
 
     #Exit non-zero when fatal error is encountered (because fastq-multx doesn't)
-    my $fatal_pats  = ['Error: number of input files \(\d+\) must match ' .
-                       'number of output files',
-                       'No such file or directory'];
-    my $fatal_pat   = join('|',@$fatal_pats);
+    my $fatal_pats =
+      ['Error: number of input files \(\d+\) must match number of output files',
+       'No such file or directory',
+       'Returning error because of i\/o error during file close'];
+    my $fatal_pat = join('|',@$fatal_pats);
 
     unless($line =~ /$filter_pat/i)
       {print STDERR ($line)}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -356,6 +356,19 @@ check_test_results
 #EXIT_CODE=$?
 #EXPECTED_EXIT_CODE=0
 #check_test_results
+TEST=test_26
+echo -e "\033[1;33mSKIPPING\033[0m $TEST"
+
+
+# Test that "Returning error because of i/o error during file close" is fatal
+TEST=test_27
+rm -f ${TEST_OUTPUT}/${TEST}_* 2> /dev/null
+OUTPUTS=""
+NOT_OUTPUTS="summary.out error.out"
+$BARCODE_SPLITTER --fast-multx ./simulate_multx_error_test_27.pl --mismatches 2 --gzipin --gzipout --bcfile "${TEST_DATA}/barcode_splitter_barcodes.txt" <(cat "${TEST_DATA}/barcode_splitter1.fastq.gz") --prefix "${TEST_OUTPUT}/${TEST}_" --suffix .out --idxread 1 --split_all $DEBUG_OPT 2> ${TEST_OUTPUT}/${TEST}_error.out 1> ${TEST_OUTPUT}/${TEST}_summary.out
+EXIT_CODE=$?
+EXPECTED_EXIT_CODE=1
+check_test_results
 
 
 exit $EXIT_STATUS

--- a/tests/simulate_multx_error_test_27.pl
+++ b/tests/simulate_multx_error_test_27.pl
@@ -1,0 +1,8 @@
+#!/usr/bin/env perl
+
+use warnings;
+use strict;
+
+print STDERR ("Returning error because of i/o error during file close");
+
+exit(3);


### PR DESCRIPTION
I added a test using a simulated fastq-multx case.

I'll probably submit another change after I update `IO::Pipe::Producer` to set the error code of the system call in `$?`.

To run the tests yourself:

```
cd tests
./run_tests.sh
```